### PR TITLE
Bump to GNOME 3.34

### DIFF
--- a/com.github.maoschanz.drawing.json
+++ b/com.github.maoschanz.drawing.json
@@ -1,17 +1,14 @@
 {
 	"app-id" : "com.github.maoschanz.drawing",
 	"runtime" : "org.gnome.Platform",
-	"runtime-version" : "3.32",
+	"runtime-version" : "3.34",
 	"sdk" : "org.gnome.Sdk",
 	"command" : "drawing",
 	"finish-args" : [
 		"--share=ipc",
 		"--socket=x11",
 		"--socket=wayland",
-		"--filesystem=xdg-run/dconf",
-		"--filesystem=~/.config/dconf:ro",
-		"--talk-name=ca.desrt.dconf",
-		"--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+        	"--metadata=X-DConf=migrate-path=/com/github/maoschanz/drawing/"
 	],
 	"modules" : [
 		{


### PR DESCRIPTION
This also removes dconf access & migrate the old settings.