### PR TITLE
GNOME runtime 41, FEDC support

### DIFF
--- a/com.github.maoschanz.drawing.json
+++ b/com.github.maoschanz.drawing.json
@@ -1,24 +1,31 @@
 {
-	"app-id" : "com.github.maoschanz.drawing",
-	"runtime" : "org.gnome.Platform",
-	"runtime-version" : "41",
-	"sdk" : "org.gnome.Sdk",
-	"command" : "drawing",
-	"finish-args" : [
-		"--share=ipc",
-		"--socket=fallback-x11",
-		"--socket=wayland",
-		"--metadata=X-DConf=migrate-path=/com/github/maoschanz/drawing/"
-	],
-	"modules" : [{
-		"name" : "drawing",
-		"buildsystem" : "meson",
-		"sources" : [{
-			"type" : "git",
-			"tag" : "0.8.3",
-			"commit" : "af650c451444f26faa7529196baf599e4561b85d",
-			"url" : "https://github.com/maoschanz/drawing"
-		}]
-	}]
+    "app-id": "com.github.maoschanz.drawing",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "41",
+    "sdk": "org.gnome.Sdk",
+    "command": "drawing",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--metadata=X-DConf=migrate-path=/com/github/maoschanz/drawing/"
+    ],
+    "modules": [
+        {
+            "name": "drawing",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "tag": "0.8.3",
+                    "commit": "af650c451444f26faa7529196baf599e4561b85d",
+                    "url": "https://github.com/maoschanz/drawing",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^([\\d.]+)$"
+                    }
+                }
+            ]
+        }
+    ]
 }
-

--- a/com.github.maoschanz.drawing.json
+++ b/com.github.maoschanz.drawing.json
@@ -1,7 +1,7 @@
 {
 	"app-id" : "com.github.maoschanz.drawing",
 	"runtime" : "org.gnome.Platform",
-	"runtime-version" : "40",
+	"runtime-version" : "41",
 	"sdk" : "org.gnome.Sdk",
 	"command" : "drawing",
 	"finish-args" : [


### PR DESCRIPTION
Updated GNOME runtime to 41, added FEDC support.